### PR TITLE
Document GPT submissions for easy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,3 +538,32 @@ GENTLE_REMINDER_MESSAGE = "ההודעה החדשה שלך כאן"
 - `message_handler.py` - הוסרה קריאה כפולה ל-`log_to_sheets`
 
 **תוצאה:** עכשיו כל הודעה נשמרת רק פעם אחת בגיליון, בשורה אחת כמו שצריך.
+
+---
+
+## 🔍 צפייה בלוג JSONL של GPT
+
+> החל מגרסת **openai_calls.jsonl** (או כל נתיב שתגדיר ב-`GPTJSONLLogger`) כל קריאה ל-GPT נשמרת בשורה אחת בפורמט JSON. כך תוכל לעיין בהן בקלות:
+
+### 1. VS Code
+
+1. פתח את הקובץ `data/openai_calls.jsonl`.
+2. התקן את ההרחבה **JSON Lines** (אם טרם מותקנת) ‑ היא מציגה כל שורה כאובייקט JSON מעוצב.
+3. `Ctrl+Shift+P → JSON Lines: Pretty print` יעצב שורה נבחרת.
+4. חיפוש (`Ctrl+F`) עובד כרגיל – אפשר למצוא System Prompt, user
+aiming, או שדות token usage.
+
+### 2. פקודות טרמינל מהירות
+
+| פעולה                  | פקודה |
+|------------------------|-------|
+| להציג 10 השורות האחרונות | `tail -n 10 data/openai_calls.jsonl` |
+| לעקוב בלייב            | `tail -f data/openai_calls.jsonl` |
+| לעצב בזמן אמת עם *jq*  | `tail -f data/openai_calls.jsonl \| jq -C .` |
+| פורמט צבעוני לקובץ שלם | `jq -C . data/openai_calls.jsonl \| less -R` |
+| להציג רק ההודעות שנשלחו | `jq -C '.request.messages' data/openai_calls.jsonl` |
+| להציג רק מספר הטוקנים  | `jq '.response.usage' data/openai_calls.jsonl` |
+
+*הסבר קצר*: כל שורה היא אובייקט JSON עצמאי → לכן יש להעביר ל-`jq` בלי דגל `-s`. אם תרצה לנתח סטטיסטית (למשל BigQuery/Snowflake) פשוט טען את הקובץ כ-JSONL.
+
+---

--- a/example_gpt_logger_usage.py
+++ b/example_gpt_logger_usage.py
@@ -36,6 +36,9 @@ def main():
         temperature=0.5,
     )
 
+    # If you already calculated cost elsewhere, pass it in:
+    # logger.chat_completion(client, cost_usd=0.0021, **same_payload)
+
     print(response.choices[0].message.content)
 
 

--- a/example_gpt_logger_usage.py
+++ b/example_gpt_logger_usage.py
@@ -1,0 +1,43 @@
+import os
+
+# The OpenAI SDK must be installed; otherwise this script will not run.
+# We import inside a try/except so static linters in environments without the
+# package do not complain.
+try:
+    from openai import OpenAI  # type: ignore
+except ImportError:  # pragma: no cover – runtime only
+    OpenAI = None  # type: ignore
+
+# >>> Replace with your real key or rely on env var OPENAI_API_KEY
+# os.environ["OPENAI_API_KEY"] = "sk-..."
+
+from gpt_jsonl_logger import GPTJSONLLogger
+
+
+def main():
+    # Ensure the SDK is available before instantiating
+    if OpenAI is None:  # type: ignore
+        raise ImportError("The 'openai' package is required. Run: pip install openai>=1.0")
+
+    # Initialise the OpenAI client (from openai>=1.0)
+    client = OpenAI()
+
+    # You can place the log file wherever you want. Here we keep it under data/
+    logger = GPTJSONLLogger("data/openai_calls.jsonl")
+
+    # Standard chat payload – nothing special
+    response = logger.chat_completion(
+        client,
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Write a funny haiku about coffee."},
+        ],
+        temperature=0.5,
+    )
+
+    print(response.choices[0].message.content)
+
+
+if __name__ == "__main__":
+    main()

--- a/gpt_a_handler.py
+++ b/gpt_a_handler.py
@@ -451,35 +451,29 @@ def get_main_response_sync(full_messages, chat_id=None, message_id=None, use_ext
         # שלב 4: חישוב עלויות
         billing_start_time = time.time()
         
-        # 🔬 מדידת ביצועים מבוטלת זמנית
-        
-        # 📊 מעקב אחר חיוב
-        if hasattr(response, 'usage'):
-            try:
-                cost_usd = litellm.completion_cost(completion_response=response)
-                if cost_usd > 0:
-                    billing_status = billing_guard.add_cost(cost_usd, response.model, "paid" if use_extra_emotion else "free")
-                    
-                    # התראות לאדמין
-                    if billing_status["warnings"]:
-                        for warning in billing_status["warnings"]:
-                            logging.warning(f"[💰 תקציב] {warning}")
-                    
-                    # התראה בטלגרם אם צריך
-                    status = billing_guard.get_current_status()
-                    alert_billing_issue(
-                        cost_usd=cost_usd,
-                        model_name=response.model,
-                        tier="paid" if use_extra_emotion else "free",
-                        daily_usage=status["daily_usage"],
-                        monthly_usage=status["monthly_usage"],
-                        daily_limit=status["daily_limit"],
-                        monthly_limit=status["monthly_limit"]
-                    )
+        #  מעקב אחר חיוב
+        if 'cost_info' in locals():
+            cost_usd = cost_info.get("cost_total", 0.0)
+            if cost_usd and cost_usd > 0:
+                billing_status = billing_guard.add_cost(cost_usd, response.model, "paid" if use_extra_emotion else "free")
                 
-            except Exception as cost_error:
-                logging.error(f"[💰] שגיאה בחישוב עלות: {cost_error}")
-        
+                # התראות לאדמין
+                if billing_status.get("warnings"):
+                    for warning in billing_status["warnings"]:
+                        logging.warning(f"[💰 תקציב] {warning}")
+                
+                # התראה בטלגרם אם צריך
+                status = billing_guard.get_current_status()
+                alert_billing_issue(
+                    cost_usd=cost_usd,
+                    model_name=response.model,
+                    tier="paid" if use_extra_emotion else "free",
+                    daily_usage=status["daily_usage"],
+                    monthly_usage=status["monthly_usage"],
+                    daily_limit=status["daily_limit"],
+                    monthly_limit=status["monthly_limit"]
+                )
+            
         billing_time = time.time() - billing_start_time
         print(f"⚡ [TIMING] Billing time: {billing_time:.3f}s")
         

--- a/gpt_jsonl_logger.py
+++ b/gpt_jsonl_logger.py
@@ -43,7 +43,14 @@ class GPTJSONLLogger:
     # ------------------------------------------------------------------
     # Public helpers
     # ------------------------------------------------------------------
-    def chat_completion(self, client: Any, /, **payload: Any):
+    def chat_completion(
+        self,
+        client: Any,
+        /,
+        *,
+        cost_usd: float | None = None,
+        **payload: Any,
+    ):
         """Provider-agnostic chat completion with automatic JSONL logging.
 
         Supported clients (first positional arg):
@@ -85,19 +92,6 @@ class GPTJSONLLogger:
                 response_dict = response.to_dict_recursive()  # type: ignore[attr-defined]
             except AttributeError:
                 response_dict = json.loads(json.dumps(response, default=str))
-
-        # ------------------------------------------------------------------
-        # Optional: compute cost via LiteLLM if available
-        # ------------------------------------------------------------------
-        cost_usd = None
-        try:
-            import litellm  # type: ignore  # local import to avoid hard dependency
-
-            # Only works if response originates from litellm or is OpenAI-style
-            cost_usd = litellm.completion_cost(completion_response=response)  # type: ignore[arg-type]
-        except Exception:
-            # Cost calculation failed/unavailable – leave as None
-            pass
 
         # Append to log
         self._append_log(request_copy, response_dict, endpoint_name, cost_usd)

--- a/gpt_jsonl_logger.py
+++ b/gpt_jsonl_logger.py
@@ -1,0 +1,88 @@
+import json
+import os
+import threading
+from datetime import datetime
+from typing import Any, Dict
+
+
+class GPTJSONLLogger:
+    """A tiny helper that logs every call *and* response to OpenAI Chat API.
+
+    • Each log line is a single JSON object → perfect for `jq`, BigQuery, Athena, etc.
+    • Thread-safe append so you can share one logger instance across your whole app.
+    • Fully self-contained: no external deps besides the `openai` client you already use.
+
+    Usage (Python ≥3.8):
+    -----------------------------------------------------------------------
+    from openai import OpenAI
+    from gpt_jsonl_logger import GPTJSONLLogger
+
+    client = OpenAI()  # relies on env var OPENAI_API_KEY
+    logger = GPTJSONLLogger("data/openai_calls.jsonl")
+
+    response = logger.chat_completion(
+        client,
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+        ],
+        temperature=0.7,
+    )
+
+    print(response.choices[0].message.content)
+    -----------------------------------------------------------------------
+    """
+
+    def __init__(self, log_path: str = "openai_calls.jsonl") -> None:
+        self.log_path = log_path
+        # Make sure parent directory exists (but ignore if log_path has no dir part)
+        os.makedirs(os.path.dirname(log_path) or ".", exist_ok=True)
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def chat_completion(self, client: Any, /, **payload: Any):
+        """Thin wrapper around ``client.chat.completions.create`` *with logging*.
+
+        The original response object is returned unchanged so your existing code
+        keeps working. The request payload **and** serialised response are
+        appended to ``self.log_path`` as a single JSON object.
+        """
+        # Keep a deep-ish copy of what the caller sent (it may be mutated by SDK)
+        request_copy: Dict[str, Any] = json.loads(json.dumps(payload, default=str))
+
+        response = client.chat.completions.create(**payload)
+
+        # Convert response object to plain Python primitives so it's JSON-friendly
+        response_dict: Any
+        try:
+            # openai>=1.0 uses Pydantic -> model_dump()
+            response_dict = response.model_dump()
+        except AttributeError:
+            try:
+                # openai<1.0 legacy helper
+                response_dict = response.to_dict_recursive()
+            except AttributeError:
+                # Fallback – best-effort string representation
+                response_dict = str(response)
+
+        self._append_log(request_copy, response_dict)
+        return response
+
+    # ------------------------------------------------------------------
+    # Internal utils
+    # ------------------------------------------------------------------
+    def _append_log(self, request_body: Dict[str, Any], response_body: Any) -> None:
+        """Append a single JSONL line atomically (thread-safe)."""
+        entry = {
+            "ts": datetime.utcnow().isoformat() + "Z",
+            "endpoint": "chat/completions",
+            "request": request_body,
+            "response": response_body,
+        }
+        line = json.dumps(entry, ensure_ascii=False)
+        with self._lock:
+            with open(self.log_path, "a", encoding="utf-8") as file:
+                file.write(line + "\n")


### PR DESCRIPTION
Add a universal JSONL logger for GPT interactions and remove duplicate cost calculation.

The user required exact, detailed logging of all parameters sent to and received from GPT providers. This PR introduces a new `GPTJSONLLogger` that writes requests and responses to a JSONL file, ensuring UTF-8 support for Hebrew. It also refactors cost calculation to prevent duplication, with the logger now accepting a pre-calculated `cost_usd` from the central `calculate_gpt_cost` function, and a minor adjustment in `gpt_a_handler.py` to reuse existing cost information.