### PR TITLE
Prompt user for confirmation again

### DIFF
--- a/message_handler.py
+++ b/message_handler.py
@@ -874,15 +874,17 @@ async def handle_pending_user_background(update, context, chat_id, user_msg):
                 await send_system_message(update, chat_id, "הייתה בעיה באישור. אנא נסה שוב.")
                 
         elif user_msg.strip() == DECLINE_BUTTON_TEXT():
-            # דחיית תנאים
-            decline_msg = not_approved_message()
-            await send_system_message(update, chat_id, decline_msg, reply_markup=ReplyKeyboardRemove())
-            
-        else:
-            # הודעה על הצורך באישור תנאים
-            pending_msg = "אנא אשר את תנאי השימוש על ידי לחיצה על הכפתור 'מאשר' למטה."
+            # דחיית תנאים – הצגת הודעת האישור מחדש
+            # במקום להחזיר את המשתמש לשלב הקוד (שעלול ליצור מבוי סתום),
+            # נשלח שוב את הודעת האישור עם המקלדת כדי שיוכל לאשר במידת הצורך.
             await send_approval_message(update, chat_id)
-            
+            return
+
+        else:
+            # כל הודעה אחרת – להזכיר את הצורך באישור תנאי השימוש
+            await send_approval_message(update, chat_id)
+            return
+
     except Exception as e:
         logging.error(f"[Permissions] שגיאה בטיפול במשתמש ממתין לאישור: {e}")
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure user approval message is re-displayed if a new user declines or sends any other message while pending approval.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, if a new user selected 'לא מאשר' (disapprove) during the onboarding process, the bot would remove the keyboard and prompt for the secret code, leading to a dead end. This change ensures the approval message is re-presented, allowing the user to proceed or re-evaluate their choice, and also handles any other unexpected messages by re-displaying the approval prompt.